### PR TITLE
Allow for compilation under newest compiler version 0.1.084 by adding…

### DIFF
--- a/module.jai
+++ b/module.jai
@@ -20,4 +20,6 @@
     // or interactively). This is the bulk of the actual code in this module.
 
     #load "runtime.jai";
+    #library,system,link_always "advapi32";
+    #library,system,link_always "user32";
 }


### PR DESCRIPTION
… libraries to the module.jai file that used to be linked by default