### PR TITLE
Fixing link errors on windows

### DIFF
--- a/runtime.jai
+++ b/runtime.jai
@@ -37,7 +37,7 @@
         Compiler :: #import "Compiler";
         // Tracy requires these libs to work.
         #if OS == .WINDOWS {
-            TRACY_DEPENDENCY_LIBS :: string.["ws2_32.lib", "msvcprtd.lib"];
+            TRACY_DEPENDENCY_LIBS :: string.["ws2_32.lib", "msvcprtd.lib", "advapi32.lib", "user32.lib"];
         } else {
             TRACY_DEPENDENCY_LIBS :: string.["-lpthread", "-ldl", "-lc++"];
         }


### PR DESCRIPTION
This does the exact same thing as #1, but appending the necessary libraries to TRACY_DEPENDENCY_LIBS in the OS == .WINDOWS section, so it should be portable and not cause problems.